### PR TITLE
Set R option for reticulate + conda

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -43,10 +43,10 @@ jobs:
         
       - name: Install spacy
         run: |
-          Sys.setenv(RETICULATE_MINICONDA_PATH = 'miniconda/')
           reticulate::install_miniconda()
-          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9', conda = 'miniconda/bin/conda')
-          spacyr::spacy_install(conda = 'miniconda/bin/conda', prompt = FALSE)
+          echo "options(reticulate.conda_binary = reticulate:::miniconda_conda())" >> .Rprofile
+          reticulate::conda_create('r-reticulate', packages = 'python==3.6.9')
+          spacyr::spacy_install(prompt = FALSE)
         shell: Rscript {0}
       
       - name: Build site


### PR DESCRIPTION
I'm doing this as a PR so you can check it out and merge it in if it all looks good to you. I talked with the reticulate folks at RStudio and this is how they recommend getting GH Actions and reticulate and conda to all play nicely together; they think it will be more robust to future changes than the other way. It is what we are using [in parsnip](https://github.com/tidymodels/parsnip/blob/master/.github/workflows/test-coverage.yaml) now and it works well there.

They also said that they are going to try for an upcoming change to reticulate to just always prefer the conda as the first choice, which will eventually be nice.